### PR TITLE
fix: update legacy splat operator

### DIFF
--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -85,12 +85,12 @@ output "non_eks_accounts" {
 }
 
 output "organization_scp_id" {
-  value       = join("", module.organization_service_control_policies.*.organizations_policy_id)
+  value       = join("", module.organization_service_control_policies[*].organizations_policy_id)
   description = "Organization Service Control Policy ID"
 }
 
 output "organization_scp_arn" {
-  value       = join("", module.organization_service_control_policies.*.organizations_policy_arn)
+  value       = join("", module.organization_service_control_policies[*].organizations_policy_arn)
   description = "Organization Service Control Policy ARN"
 }
 


### PR DESCRIPTION
## what

- Replace the legacy "attribute-only" splat expressions which use the sequence `.*` with the newer expression`[*]`

## why

Earlier versions of the Terraform language had a slightly different version of splat expressions, which Terraform continues to support for backward compatibility. This older variant is less useful than the modern form described above, and so Hashicorp recommends against using it in new configurations.

## references

- [Splat Expressions](https://developer.hashicorp.com/terraform/language/expressions/splat#legacy-attribute-only-splat-expressions)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated Terraform output syntax for organization service control policies
	- Replaced splat operator (`.*`) with modern indexing syntax (`[*]`)
	- Maintained existing output functionality and descriptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->