### PR TITLE
Add new output `account_name_id_map`

### DIFF
--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -113,3 +113,8 @@ output "organizational_unit_names_organizational_unit_scp_arns" {
   value       = local.organizational_unit_names_organizational_unit_scp_arns
   description = "Map of OU names to SCP ARNs"
 }
+
+output "account_name_id_map" {
+  value       = { for k, v in local.account_info_map : k => v.id }
+  description = "Map of account names to account IDs (including root account)"
+}


### PR DESCRIPTION
## what
* another output

## why
* Provides a map of account_name to id for all accounts including organization owner.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new output that provides a map of account names to their account IDs, including the root account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->