### PR TITLE
Added variable to control whether SCPs should be created

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -256,22 +256,22 @@ locals {
   )
 
   # Map of account names to SCP IDs
-  account_names_account_scp_ids = service_control_policies_enabled ? {
+  account_names_account_scp_ids = var.service_control_policies_enabled ? {
     for k, v in local.account_names_service_control_policy_statements_map : k => module.accounts_service_control_policies[k].organizations_policy_id
   } : {}
 
   # Map of account names to SCP ARNs
-  account_names_account_scp_arns = service_control_policies_enabled ? {
+  account_names_account_scp_arns = var.service_control_policies_enabled ? {
     for k, v in local.account_names_service_control_policy_statements_map : k => module.accounts_service_control_policies[k].organizations_policy_arn
   } : {}
 
   # Map of OU names to SCP IDs
-  organizational_unit_names_organizational_unit_scp_ids = service_control_policies_enabled ? {
+  organizational_unit_names_organizational_unit_scp_ids = var.service_control_policies_enabled ? {
     for k, v in local.organizational_unit_names_service_control_policy_statements_map : k => module.organizational_units_service_control_policies[k].organizations_policy_id
   } : {}
 
   # Map of OU names to SCP ARNs
-  organizational_unit_names_organizational_unit_scp_arns = service_control_policies_enabled ? {
+  organizational_unit_names_organizational_unit_scp_arns = var.service_control_policies_enabled ? {
     for k, v in local.organizational_unit_names_service_control_policy_statements_map : k => module.organizational_units_service_control_policies[k].organizations_policy_arn
   } : {}
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -256,24 +256,24 @@ locals {
   )
 
   # Map of account names to SCP IDs
-  account_names_account_scp_ids = {
+  account_names_account_scp_ids = service_control_policies_enabled ? {
     for k, v in local.account_names_service_control_policy_statements_map : k => module.accounts_service_control_policies[k].organizations_policy_id
-  }
+  } : {}
 
   # Map of account names to SCP ARNs
-  account_names_account_scp_arns = {
+  account_names_account_scp_arns = service_control_policies_enabled ? {
     for k, v in local.account_names_service_control_policy_statements_map : k => module.accounts_service_control_policies[k].organizations_policy_arn
-  }
+  } : {}
 
   # Map of OU names to SCP IDs
-  organizational_unit_names_organizational_unit_scp_ids = {
+  organizational_unit_names_organizational_unit_scp_ids = service_control_policies_enabled ? {
     for k, v in local.organizational_unit_names_service_control_policy_statements_map : k => module.organizational_units_service_control_policies[k].organizations_policy_id
-  }
+  } : {}
 
   # Map of OU names to SCP ARNs
-  organizational_unit_names_organizational_unit_scp_arns = {
+  organizational_unit_names_organizational_unit_scp_arns = service_control_policies_enabled ? {
     for k, v in local.organizational_unit_names_service_control_policy_statements_map : k => module.organizational_units_service_control_policies[k].organizations_policy_arn
-  }
+  } : {}
 
   account_info_map = merge({ for acc in local.all_accounts : acc.name => merge({ for k, v in acc : k => v if k != "name" },
     {

--- a/src/main.tf
+++ b/src/main.tf
@@ -171,7 +171,7 @@ module "organization_service_control_policies" {
   source  = "cloudposse/service-control-policies/aws"
   version = "0.15.1"
 
-  count = length(local.organization_service_control_policy_statements) > 0 ? 1 : 0
+  count = var.service_control_policies_enabled && length(local.organization_service_control_policy_statements) > 0 ? 1 : 0
 
   attributes                         = concat(module.this.attributes, ["organization"])
   service_control_policy_statements  = local.organization_service_control_policy_statements
@@ -186,7 +186,7 @@ module "accounts_service_control_policies" {
   source  = "cloudposse/service-control-policies/aws"
   version = "0.15.1"
 
-  for_each = local.account_names_service_control_policy_statements_map
+  for_each = var.service_control_policies_enabled ? local.account_names_service_control_policy_statements_map : {}
 
   attributes                         = concat(module.this.attributes, [each.key, "account"])
   service_control_policy_statements  = each.value
@@ -201,7 +201,7 @@ module "organizational_units_service_control_policies" {
   source  = "cloudposse/service-control-policies/aws"
   version = "0.15.1"
 
-  for_each = local.organizational_unit_names_service_control_policy_statements_map
+  for_each = var.service_control_policies_enabled ? local.organizational_unit_names_service_control_policy_statements_map : {}
 
   attributes                         = concat(module.this.attributes, [each.key, "ou"])
   service_control_policy_statements  = each.value

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -24,9 +24,26 @@ variable "enabled_policy_types" {
   description = "List of Organizations policy types to enable in the Organization Root. Organization must have feature_set set to ALL. For additional information about valid policy types (e.g. SERVICE_CONTROL_POLICY and TAG_POLICY), see the [AWS Organizations API Reference](https://docs.aws.amazon.com/organizations/latest/APIReference/API_EnablePolicyType.html)"
 }
 
+variable "organization_enabled" {
+  type        = bool
+  description = "A boolean flag indicating whether to create an Organization or use the existing one"
+  default     = true
+}
+
 variable "organization_config" {
   type        = any
   description = "Organization, Organizational Units and Accounts configuration"
+}
+
+variable "service_control_policies_enabled" {
+  type        = bool
+  description = <<-DOC
+    A boolean flag that determines whether Service Control Policies (SCPs) should be created.
+    During a cold start, some SCPs might block the creation or updating of resources.
+    When set to `false`, the creation of SCPs can be postponed and performed as the last step of the cold start process.
+    When set to `true` (the default), the SCPs are created immediately.
+  DOC
+  default     = true
 }
 
 variable "service_control_policies_config_paths" {
@@ -34,8 +51,3 @@ variable "service_control_policies_config_paths" {
   description = "List of paths to Service Control Policy configurations"
 }
 
-variable "organization_enabled" {
-  type        = bool
-  description = "A boolean flag indicating whether to create an Organization or use the existing one"
-  default     = true
-}


### PR DESCRIPTION
Added a boolean flag `service_control_policies_enabled` to determine whether Service Control Policies (SCPs) should be created. By default, this is set to `true`, preserving the current behaviour.

### Usage
When provisioning the Ref Arch from scratch (cold start), some Service Control Policies (SCPs) can prevent resources from being created or updated.

* If `service_control_policies_enabled` is `false`, Terraform skips creating the SCPs.
* If `service_control_policies_enabled` is `true` (default), Terraform creates the SCPs right away.

Because of this, the cold start process can now work in two steps:
1. First run (no SCPs yet): Create the organization and accounts with SCPs disabled:
```shell
terraform deploy cloudposse/aws-account \
  -target=aws_organizations_organization.this[0] \
  -var service_control_policies_enabled=false \
  -s core-gbl-root
```
2. Second run (add SCPs): After everything else is ready, enable and provision the SCPs:
```shell
terraform deploy cloudposse/aws-account \
  -target=aws_organizations_organization.this[0] \
  -var service_control_policies_enabled=true \
  -s core-gbl-root
```