### PR TITLE
feat: `aws_iam_organizations_features`

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -111,6 +111,11 @@ resource "aws_organizations_organization" "this" {
   feature_set                   = "ALL"
 }
 
+resource "aws_iam_organizations_features" "this" {
+  count            = var.organization_enabled ? 1 : 0
+  enabled_features = var.organization_enabled_features
+}
+
 locals {
   organization_root_account_id = var.organization_enabled ? aws_organizations_organization.this[0].roots[0].id : data.aws_organizations_organization.existing[0].roots[0].id
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -114,6 +114,8 @@ resource "aws_organizations_organization" "this" {
 resource "aws_iam_organizations_features" "this" {
   count            = var.organization_enabled ? 1 : 0
   enabled_features = var.organization_enabled_features
+
+  depends_on = [aws_organizations_organization.this]
 }
 
 locals {

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -39,3 +39,9 @@ variable "organization_enabled" {
   description = "A boolean flag indicating whether to create an Organization or use the existing one"
   default     = true
 }
+
+variable "organization_enabled_features" {
+  type        = list(string)
+  description = "List of Organizations features to enable in the Organization Root. Organization must have feature_set set to ALL. For additional information about valid features (e.g. RootCredentialsManagement and RootSessions), see the [AWS Organizations API Reference](https://docs.aws.amazon.com/organizations/latest/APIReference/API_EnableFeature.html)"
+  default     = []
+}


### PR DESCRIPTION
## what
- Added optional resource, `aws_iam_organizations_features`

## why
- We can use this to enable `RootCredentialsManagement` and `RootSessions`. By doing so, we can centralized root access and remove the requirement for root creds in each child account

For example

```yaml
components:
  terraform:
    account:
      vars:
...
        organization_enabled_features:
          - RootCredentialsManagement
          - RootSessions
```

## references
> Manages centralized root access features across AWS member accounts managed using AWS Organizations. More information about managing root access in IAM can be found in the [Centralize root access for member accounts](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-enable-root-access.html).
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_organizations_features

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enable and manage AWS Organizations features at the Organization Root level.
  * Feature activation is conditional and tied to organization state.
  * Configure multiple features at once using a simple list-based setting with sensible defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->